### PR TITLE
[#69] 헤더 수정

### DIFF
--- a/components/organisms/Header/index.tsx
+++ b/components/organisms/Header/index.tsx
@@ -44,10 +44,5 @@ const StyledPanels = styled.h1`
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    Button:first-child {
-        margin-right: 32px;
-    }
-    Button {
-        margin-left: 32px;
-    }
+    gap: 32px;
 `;

--- a/components/organisms/Header/index.tsx
+++ b/components/organisms/Header/index.tsx
@@ -1,6 +1,10 @@
 import React, { FunctionComponent } from 'react';
+
 import Logo from 'components/atoms/Logo';
 import Button from 'components/atoms/Button';
+import SearchButton from 'components/atoms/SearchButton';
+import ThemeSwitch from 'components/atoms/ThemeSwitch';
+
 import styled from '@emotion/styled';
 import Link from 'next/link';
 
@@ -13,7 +17,11 @@ const Header: FunctionComponent = () => {
                 </Link>
             </StyledHeader>
             {/*Todo 로그아웃 기능 구현*/}
-            <Button category="secondary">로그아웃</Button>
+            <StyledPanels>
+                <SearchButton />
+                <ThemeSwitch />
+                <Button category="secondary">로그아웃</Button>
+            </StyledPanels>
         </StyledWrapper>
     );
 };
@@ -24,10 +32,22 @@ const StyledWrapper = styled.header`
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 50px 0 80px;
+    padding: 0 80px 0 80px;
     height: 164px;
 `;
 
 const StyledHeader = styled.h1`
     margin: 0;
+`;
+
+const StyledPanels = styled.h1`
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    Button:first-child {
+        margin-right: 32px;
+    }
+    Button {
+        margin-left: 32px;
+    }
 `;


### PR DESCRIPTION
### 구현내용

- 헤더 수정.

![image](https://user-images.githubusercontent.com/52649378/132951158-abe6cab6-144c-4f6e-a35b-84b52691379f.png)

![image](https://user-images.githubusercontent.com/52649378/132951164-dfb94923-a9b4-47a2-a5bf-5a179e0a40e0.png)

### 특이사항

![image](https://user-images.githubusercontent.com/52649378/132951172-1fe4d363-075e-4102-aae9-1c123d6ca86e.png)

아래 47번쨰줄, 50번째줄에 보면, 

50번째줄에선 `StyledPanels` 안에 `Button` 을 잘 찾아서 margin left를 잘 주는데, 

47번쨰줄에서는 아래 코드처럼 

```javascript
const styledPanels = styled.h1`
  SearchButton {
    margin-right: 32px;
  }
`;
```

이렇게가 안되더라구요. 원래 styled component에서는 새롭게 정의한 스타일 컴포넌트 지정이 되는걸로 알고있는데.. 혹시 이유를 아시나요? ㅠ

closes #69