### PR TITLE
[#85] 검색 모달, 푸터

### DIFF
--- a/components/molecules/GameSearchResult/index.tsx
+++ b/components/molecules/GameSearchResult/index.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { SimpleGameInfo } from 'types/responseInterface';
-import { format } from 'date-fns';
+import Link from 'next/link';
 
 import Button from 'components/atoms/Button';
 import Message from 'components/atoms/Message';
@@ -22,13 +22,17 @@ const GameSearchResult: FunctionComponent<GameSearchResultProps> = (props) => {
                 games.map(({ name, slug, cover, release_at, developer }) => (
                     <>
                         <GameResultSingularWrapper key={slug}>
-                            <GameImg>
-                                <img src={cover} alt="game image" height="128px" />
-                            </GameImg>
+                            <Link href="/games/[slug]" as={`/games/${slug}`}>
+                                <GameImg>
+                                    <img src={cover} alt="game image" height="128px" />
+                                </GameImg>
+                            </Link>
                             <GameInfos>
-                                <GameTitle>
-                                    {name.length > 40 ? `${name.slice(0, 40)}...` : name}
-                                </GameTitle>
+                                <Link href="/games/[slug]" as={`/games/${slug}`}>
+                                    <GameTitle>
+                                        {name.length > 40 ? `${name.slice(0, 40)}...` : name}
+                                    </GameTitle>
+                                </Link>
                                 <GameDescription>
                                     {new Date(release_at * 1000).getFullYear()} | {developer}
                                 </GameDescription>
@@ -58,7 +62,9 @@ const GameResultSingularWrapper = styled.article`
     padding: 45px 0;
 `;
 
-const GameImg = styled.div``;
+const GameImg = styled.div`
+    cursor: pointer;
+`;
 
 const GameInfos = styled.div`
     display: flex;
@@ -75,6 +81,7 @@ const GameTitle = styled.h2`
     margin-bottom: -10px;
     white-space: nowrap;
     color: ${(props) => props.theme.components.searchInput};
+    cursor: pointer;
 `;
 
 const GameDescription = styled.h2`

--- a/pages/games/[slug].tsx
+++ b/pages/games/[slug].tsx
@@ -5,6 +5,7 @@ import fetcher from 'utils/fetcher';
 import Error from 'next/error';
 import HomeTemplate from 'components/templates/Home';
 import Header from 'components/organisms/Header';
+import Footer from 'components/organisms/Footer';
 import GameDetail from 'components/organisms/GameDetail';
 import { GameInfo } from 'types/responseInterface';
 
@@ -19,7 +20,7 @@ const Game: FunctionComponent = () => {
         return <div>Loading...</div>;
     }
     return (
-        <HomeTemplate header={<Header />}>
+        <HomeTemplate header={<Header />} footer={<Footer />}>
             <GameDetail {...data} />
         </HomeTemplate>
     );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,11 +3,12 @@ import React, { FunctionComponent } from 'react';
 import HomeTemplate from 'components/templates/Home';
 import Header from 'components/organisms/Header';
 import Libraries from 'components/organisms/Libraries';
+import Footer from 'components/organisms/Footer';
 
 const home: FunctionComponent = () => {
     return (
         <>
-            <HomeTemplate header={<Header />}>
+            <HomeTemplate header={<Header />} footer={<Footer />}>
                 <Libraries />
             </HomeTemplate>
         </>


### PR DESCRIPTION
### 구현내용

- 검색모달에서 검색결과의 제목 / 이미지를 클릭하면 `/games/[slug]` 로 이동.

- `HomeTemplate` 에 Footer 추가.

closes #85 